### PR TITLE
feat: make actions with confirmation page possible

### DIFF
--- a/tests/src/Functional/WidgetTest.php
+++ b/tests/src/Functional/WidgetTest.php
@@ -138,7 +138,7 @@ class WidgetTest extends BrowserTestBase {
     ];
     $this->drupalPostForm('/entity_test/manage/1/edit', $edit, 'field_test_button');
 
-    $this->drupalPostForm('/media/delete?destination=/entity_test/manage/1/edit', [], 'Delete');
+    $this->drupalPostForm('/media/delete', [], 'Delete');
 
     $this->assertSession()->pageTextContains('Deleted 1 item');
 

--- a/tests/src/Functional/WidgetTest.php
+++ b/tests/src/Functional/WidgetTest.php
@@ -54,7 +54,10 @@ class WidgetTest extends BrowserTestBase {
     parent::setUp();
 
     $this->mediaType = $this->createMediaType('image');
-    $this->media = Media::create(['bundle' => $this->mediaType->id(), 'published' => TRUE]);
+    $this->media = Media::create([
+      'bundle' => $this->mediaType->id(),
+      'published' => TRUE,
+    ]);
 
     $handler_settings = [
       'target_bundles' => [


### PR DESCRIPTION
- Switched to media because there are more default actions
- Delete actions has a confirmation page